### PR TITLE
Range insertion not working

### DIFF
--- a/lib/phantom.js
+++ b/lib/phantom.js
@@ -1,3 +1,4 @@
+var $ = require('jquery');
 var Range = require('./range');
 var requestAnimationFrame = require('./raf');
 
@@ -8,6 +9,7 @@ var Phantom = Range.extend({
       label: '+'
     }, options));
     this.$el.addClass('elessar-phantom');
+    this.on('mousedown touchstart', $.proxy(this.mousedown, this));
   },
 
   mousedown: function(ev) {


### PR DESCRIPTION
Phantoms are marked as readonly, so the mousedown event handler isn't attached.

Reported by @rops via email.
