### PR TITLE
add height property to range style

### DIFF
--- a/elessar.css
+++ b/elessar.css
@@ -55,6 +55,7 @@
   background: blue;
   width: 0;
   z-index: 10;
+  height: 100%;
 }
 .elessar-vertical .elessar-range {
   width: auto;


### PR DESCRIPTION
The ranges were not visible until I added to `height: 100%;` to the `.elessar-range` class.

I'm using Chrome 48 on OS X.

Before:

<img width="827" alt="screen shot 2016-02-18 at 11 53 36 pm" src="https://cloud.githubusercontent.com/assets/2289/13169499/e88c4790-d69a-11e5-9a19-5f8da3b5a65d.png">

After:

<img width="828" alt="screen shot 2016-02-18 at 11 53 53 pm" src="https://cloud.githubusercontent.com/assets/2289/13169506/ee81abfe-d69a-11e5-8b39-26e2cc782194.png">

Using this code:

```js
const $ = require('jquery')
const RangeBar = require('elessar')

$(function(){
  var bar = new RangeBar({
    values: [[20,50]],
    min: 0,
    max: 100,
    maxRanges: 1
  }).on('changing', function(ev, ranges, changed) {
    console.log(ranges[0])
  })

  $('body').prepend(bar.$el)
})
```